### PR TITLE
fix: standardize gwei variable naming in assignment

### DIFF
--- a/SolidityBeginnerCourse/transactions-ether-and-wei/etherAndWei.md
+++ b/SolidityBeginnerCourse/transactions-ether-and-wei/etherAndWei.md
@@ -15,7 +15,7 @@ One `ether` is equal to 1,000,000,000,000,000,000 (10^18) `wei` (line 11).
 <a href="https://www.youtube.com/watch?v=ybPQsjssyNw" target="_blank">Watch a video tutorial on Ether and Wei</a>.
 
 ## ⭐️ Assignment
-1. Create a `public` `uint` called `oneGWei` and set it to 1 `gwei`.
-2. Create a `public` `bool` called `isOneGWei` and set it to the result of a comparison operation between 1 gwei and 10^9.
+1. Create a `public` `uint` called `oneGwei` and set it to 1 `gwei`.
+2. Create a `public` `bool` called `isOneGwei` and set it to the result of a comparison operation between 1 gwei and 10^9.
 
 Tip: Look at how this is written for `gwei` and `ether` in the contract.


### PR DESCRIPTION
# Fix Variable Naming Inconsistency

## Issue Description
In the `transactions-ether-and-wei` exercise, there is an inconsistency in variable naming between the assignment file and the answer file:

- Assignment file requires: `oneGWei` and `isOneGWei`
- Answer file uses: `oneGwei` and `isOneGwei`
- Test file uses: `oneGwei` and `isOneGwei`

This inconsistency may cause confusion for learners.

## Changes Made
- Updated variable naming requirements in `etherAndWei.md` to use lowercase version:
  - `oneGWei` → `oneGwei`
  - `isOneGWei` → `isOneGwei`

## Reason for Changes
1. Maintain consistency with Solidity standard unit notation
2. Align with the answer file and test file
3. Prevent learner confusion due to naming inconsistency

## Testing
- The modified assignment requirements now match the answer file and test file
- No impact on existing test cases